### PR TITLE
prepare for PyPI release

### DIFF
--- a/hgtector/__init__.py
+++ b/hgtector/__init__.py
@@ -14,6 +14,6 @@ __description__ = (
     'Genome-wide detection of putative horizontal gene transfer (HGT) events '
     'based on sequence homology search hit distribution statistics')
 __license__ = 'BSD-3-Clause'
-__author__ = 'Qiyun Zhu',
-__email__ = 'qiyunzhu@gmail.com',
+__author__ = 'Qiyun Zhu'
+__email__ = 'qiyunzhu@gmail.com'
 __url__ = 'https://github.com/qiyunlab/HGTector'

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ classes = """
     Operating System :: Unix
     Operating System :: POSIX
     Operating System :: MacOS
-    Operating System :: Windows
+    Operating System :: Microsoft :: Windows
 """
 
 params = {


### PR DESCRIPTION
Tweaked some setup metadata for compatibility with PyPI. Test release is at: https://test.pypi.org/project/hgtector/2.0b3/