### PR TITLE
Fixed db failed bug

### DIFF
--- a/hgtector/database.py
+++ b/hgtector/database.py
@@ -635,7 +635,7 @@ class Database(object):
             print('Failed to retrieve the following genomes:')
             print('  ' + ', '.join(failed))
             failed = set(failed)
-            self.df.query('genome in @failures', inplace=True)
+            self.df.query('genome in @failed', inplace=True)
 
     def extract_genomes(self):
         """Extract proteins from genomes.


### PR DESCRIPTION
Fixed a typo in variable name: `failures` => `failed`. Addressed #92 . Thanks to @jeankeller .