### PR TITLE
Added support for newer diamond makedb

### DIFF
--- a/hgtector/database.py
+++ b/hgtector/database.py
@@ -866,9 +866,9 @@ class Database(object):
         # create temporary taxon map
         taxonmap = join(self.tmpdir, 'prot.accession2taxid')
         with open(taxonmap, 'w') as f:
-            f.write('accession\taccession.version\ttaxid\n')
+            f.write('accession\taccession.version\ttaxid\tgi\n')
             for p, tid in sorted(self.taxonmap.items()):
-                f.write(f'{p.rsplit(".", 1)[0]}\t{p}\t{tid}\n')
+                f.write(f'{p.rsplit(".", 1)[0]}\t{p}\t{tid}\tna\n')
 
         # build DIAMOND database
         makedirs(join(self.output, 'diamond'), exist_ok=True)


### PR DESCRIPTION
DIAMOND v2.0.7 and more recent have changed how the taxon map (`prot.accession2taxid`) should be parsed. This patch makes HGTector compatible with both older and newer DIAMOND. Addressed #90 #92 #94 .