### PR TITLE
Fixed pandas str.split kwarg issue

### DIFF
--- a/hgtector/database.py
+++ b/hgtector/database.py
@@ -391,8 +391,8 @@ class Database(object):
         # typically not necessary, just in case
         self.df.rename(columns={'# assembly_accession': 'accession'},
                        inplace=True)
-        self.df['accnov'] = self.df['accession'].str.split('.', 1).str[0]
-        self.df['genome'] = 'G' + self.df['accnov'].str.split('_', 1).str[-1]
+        self.df['accnov'] = self.df['accession'].str.split('.', n=1).str[0]
+        self.df['genome'] = 'G' + self.df['accnov'].str.split('_', n=1).str[-1]
         self.df.drop_duplicates(subset=['genome'], inplace=True)
 
         # include/exclude genome Ids


### PR DESCRIPTION
Fixed an issue regarding Pandas' `str.split` method, which now forces `n` to be a keyword argument in its recent versions. Addresses #116 #115 