### PR TITLE
overcommit + relax blast threads

### DIFF
--- a/hgtector/database.py
+++ b/hgtector/database.py
@@ -9,7 +9,7 @@
 # ----------------------------------------------------------------------------
 
 import sys
-from os import remove, makedirs, cpu_count
+from os import remove, makedirs, sched_getaffinity
 from os.path import join, isfile, isdir, getsize, basename
 from shutil import which, rmtree
 from time import sleep
@@ -242,7 +242,7 @@ class Database(object):
 
         # determine number of CPUs to use
         if self.compile in ('diamond', 'both') and not self.threads:
-            self.threads = cpu_count()
+            self.threads = len(os.sched_getaffinity(0))
             if self.threads is None:
                 self.threads = 1
 

--- a/hgtector/search.py
+++ b/hgtector/search.py
@@ -480,7 +480,11 @@ class Search(object):
                 except KeyError:
                     pass
                 if db:
+                    # check monolithic indexes
                     if all(isfile(f'{db}.{x}') for x in ('phr', 'pin', 'psq')):
+                        return db
+                    # check splitted indexes. just check *.00.suffix ones
+                    elif all(isfile(f'{db}.00.{x}') for x in ('phr', 'pin', 'psq')):
                         return db
                     elif self.method == 'blast':
                         raise ValueError(f'Invalid BLAST database: {db}.')


### PR DESCRIPTION
1) Overcommit: os.cpu_count() returns the number of physical cores available on the computer it runs on. BUT this is not the number of AVAILABLE cores for the running process.
eg in slurm allocation, you can run on a node with 96 cores, but only have access to n cores regarding the allocation.
see:
```
# Standard slurm allocation -> 1 core
maestro-submit:~ > srun python3  -c "import os; print(os.cpu_count(),  len(os.sched_getaffinity(0)))"
96 1
```
same can be checked with taskset
```
taskset -c 0 python3  -c "import os; print(os.cpu_count(),  len(os.sched_getaffinity(0)))"
96 1
```
2) blast thread limit.
blast+ is NOT limited to 8 threads, relax this hardcoded value and use num_threa
ds according to what was requested AND available ones

regards
Eric