### PR TITLE
Updated NCBI assembly summary format

### DIFF
--- a/hgtector/database.py
+++ b/hgtector/database.py
@@ -293,6 +293,9 @@ class Database(object):
             # read summary
             print(f'Reading {target} assembly summary...', end='', flush=True)
             df = pd.read_table(lfile, skiprows=1, low_memory=False)
+            col = df.columns[0]
+            if col.startswith('#'):
+                df.rename(columns={col: col.lstrip('# ')}, inplace=True)
             print(' done.')
             return df
 
@@ -365,7 +368,7 @@ class Database(object):
         asmset = set(get_categories('RefSeq'))
         if self.genbank:
             asmset.update(get_categories('GenBank'))
-        self.df = self.df[self.df['# assembly_accession'].isin(asmset)]
+        self.df = self.df[self.df['assembly_accession'].isin(asmset)]
         print(f'  Total number of genomes in categories: {self.df.shape[0]}.')
 
     def filter_genomes(self):
@@ -389,7 +392,7 @@ class Database(object):
 
         # non-redundant genome IDs
         # typically not necessary, just in case
-        self.df.rename(columns={'# assembly_accession': 'accession'},
+        self.df.rename(columns={'assembly_accession': 'accession'},
                        inplace=True)
         self.df['accnov'] = self.df['accession'].str.split('.', n=1).str[0]
         self.df['genome'] = 'G' + self.df['accnov'].str.split('_', n=1).str[-1]

--- a/hgtector/tests/test_database.py
+++ b/hgtector/tests/test_database.py
@@ -59,7 +59,7 @@ class DatabaseTests(TestCase):
 
     def test_filter_genomes(self):
         me = Database()
-        header = ('# assembly_accession', 'assembly_level', 'ftp_path')
+        header = ('assembly_accession', 'assembly_level', 'ftp_path')
         data = (('GCF_000000001.1', 'Chromosome', ''),
                 ('GCF_000000002.1', 'Complete Genome', ''),
                 ('GCF_000000003.2', 'Scaffold', ''),


### PR DESCRIPTION
The NCBI assembly summary file format has changed. The name of the first column was `# assembly_accession`, but it is now `#assembly_accession` (a whitespace was deleted). Addressed #123